### PR TITLE
feat(api): transform Mongo schema ObjectIds to strings

### DIFF
--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -34,9 +34,9 @@ export class AuthService {
         password: hashedPassword,
       });
 
-      const tokens = await this.getTokens(user._id.toString(), user.email);
+      const tokens = await this.getTokens(user._id, user.email);
       await this.usersRepository.updateUserRefreshToken(
-        user._id.toString(),
+        user._id,
         await this.hashData(tokens.refreshToken),
       );
 
@@ -68,9 +68,9 @@ export class AuthService {
     );
     if (!passwordMatches) throw new ForbiddenException('Access denied');
 
-    const tokens = await this.getTokens(user._id.toString(), user.email);
+    const tokens = await this.getTokens(user._id, user.email);
     await this.usersRepository.updateUserRefreshToken(
-      user._id.toString(),
+      user._id,
       await this.hashData(tokens.refreshToken),
     );
 
@@ -103,9 +103,9 @@ export class AuthService {
     );
     if (!tokenMatches) throw new ForbiddenException('Access denied');
 
-    const tokens = await this.getTokens(user._id.toString(), user.email);
+    const tokens = await this.getTokens(user._id, user.email);
     await this.usersRepository.updateUserRefreshToken(
-      user._id.toString(),
+      user._id,
       await this.hashData(tokens.refreshToken),
     );
 

--- a/apps/api/src/auth/tests/auth.service.spec.ts
+++ b/apps/api/src/auth/tests/auth.service.spec.ts
@@ -168,7 +168,7 @@ describe('AuthService', () => {
       });
 
       const refreshReq = await authService.refreshTokens(
-        user._id.toString(),
+        user._id,
         refreshToken,
       );
       expect(refreshReq).toBeDefined();

--- a/apps/api/src/common/mocks/entities/user.mock.ts
+++ b/apps/api/src/common/mocks/entities/user.mock.ts
@@ -5,7 +5,7 @@ import { User } from '../../../users/schemas/user.schema';
 
 export const getUserMock = (): User => {
   return {
-    _id: new Types.ObjectId(),
+    _id: new Types.ObjectId().toString(),
 
     email: faker.internet.email(),
     password: faker.internet.password(),

--- a/apps/api/src/users/schemas/user.schema.ts
+++ b/apps/api/src/users/schemas/user.schema.ts
@@ -1,12 +1,14 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import mongoose, { Document } from 'mongoose';
+import { Transform } from 'class-transformer';
+import { Document } from 'mongoose';
 
 export type UserDocument = User & Document;
 
 @Schema()
 export class User {
+  @Transform(value => value.toString())
   @Prop()
-  _id: mongoose.Types.ObjectId;
+  _id: string;
 
   @Prop({ unique: true })
   email: string;

--- a/apps/api/src/users/users.repository.ts
+++ b/apps/api/src/users/users.repository.ts
@@ -18,9 +18,9 @@ export class UsersRepository {
    */
   createUser({ email, password }): Promise<User> {
     return this.userModel.create({
+      _id: new Types.ObjectId(),
       email,
       password,
-      _id: new Types.ObjectId(),
     });
   }
 


### PR DESCRIPTION
- [x] The branch was rebased on the target branch,
- [x] Linked to GitHub Issue, closes #2 
- [x] PR has been assigned,
- [x] A review has been requested if needed.

---

## 🎯 This PR...
transforms all `ObjectIds` to `strings`, in order to have a generic to pass through all the layers.
